### PR TITLE
support all error.log files

### DIFF
--- a/apache/sumo-sources.json.tmpl
+++ b/apache/sumo-sources.json.tmpl
@@ -11,7 +11,7 @@
     }, {
         "sourceType": "LocalFile",
         "name": "apache-collector-${LOG_APPLICATION}-app",
-        "pathExpression": "/var/log/apache2/error.log",
+        "pathExpression": "/var/log/apache2/*error.log",
         "multilineProcessingEnabled": false,
         "automaticDateParsing": true,
         "forceTimeZone": false,


### PR DESCRIPTION
web outputs logs to `default_error.log`, so we should look at all `error.log` files (like we look at all `*_access.log` log files.

